### PR TITLE
fix: build on multiarch linux setups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,18 @@
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
 GO_BUILD := GOOS=$(GOOS) GOARCH=$(GOARCH) go build
 GO_BUILD_TARGET := siper
 
 CLANG := clang
 CFLAGS := -O2 -target bpf -g -c
+
+MULTIARCH ?= $(shell gcc -print-multiarch 2>/dev/null)
+ifeq ($(strip $(MULTIARCH)),)
+	MULTIARCH := $(shell gcc -dumpmachine 2>/dev/null)
+endif
+ifneq ($(wildcard /usr/include/$(MULTIARCH)),)
+	CFLAGS += -I/usr/include/$(MULTIARCH)
+endif
 
 BUILD_DIR := build
 
@@ -16,7 +26,7 @@ FORMATTER := scripts/formatter.sh
 all: siper-go siper-bpf
 
 siper-go:
-	cd cmd && $(GO_BUILD) -o ../$(BUILD_DIR)/$(GO_BUILD_TARGET) .
+	$(GO_BUILD) -o ./$(BUILD_DIR)/$(GO_BUILD_TARGET) ./cmd
 
 siper-bpf: $(BPF_OBJECTS)
 

--- a/bpf/siper.bpf.c
+++ b/bpf/siper.bpf.c
@@ -1,5 +1,4 @@
 #include <stddef.h>
-#include <netinet/in.h>
 #include <linux/in.h>
 #include <linux/if_ether.h>
 #include <linux/if_packet.h>


### PR DESCRIPTION
Avoid including glibc userspace networking headers
when compiling since they can pull in libc
internals and break in minimal/non-dev envs.

Also add the distro multiarch include dir to the
BPF CFLAGS when present so kernel UAPI headers can
resolve `asm/*` includes.

Fixes #1

### Proof

```console
$ make
GOOS=linux GOARCH=amd64 go build -o ./build/siper ./cmd
clang -O2 -target bpf -g -c -I/usr/include/x86_64-linux-gnu bpf/siper.bpf.c -o build/siper.o
```